### PR TITLE
Potential fix for code scanning alert no. 8: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "passport-google-oauth20": "^2.0.0",
     "passport-jwt": "^4.0.1",
     "passport-local": "^1.0.0",
-    "prisma": "^6.2.1"
+    "prisma": "^6.2.1",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "nodemon": "^3.1.9"

--- a/src/routes/propertyRoutes.js
+++ b/src/routes/propertyRoutes.js
@@ -60,8 +60,16 @@ propertyRoute.delete(
   propertyController.deleteProperty
 );
 
+const rateLimit = require("express-rate-limit");
+
+const adminStatusRateLimiter = rateLimit({
+  windowMs: 1 * 60 * 1000, // 1 minute
+  max: 10, // limit each IP to 10 requests per windowMs
+});
+
 propertyRoute.patch(
   "/admin/:id/status",
+  adminStatusRateLimiter,
   authenticate,
   authorize("admin"),
   propertyController.changePropertyStatus


### PR DESCRIPTION
Potential fix for [https://github.com/Project-X-organization/MyCaretaker-Backend/security/code-scanning/8](https://github.com/Project-X-organization/MyCaretaker-Backend/security/code-scanning/8)

To address the issue, we will add rate limiting to the `/admin/:id/status` route. We will use the `express-rate-limit` package to define a rate limiter middleware. This middleware will restrict the number of requests a client can make to the route within a specified time window. Specifically, we will:

1. Install the `express-rate-limit` package if it is not already installed.
2. Import the `express-rate-limit` package in the file.
3. Define a rate limiter with appropriate settings (e.g., a maximum of 10 requests per minute).
4. Apply the rate limiter to the `/admin/:id/status` route.

This approach ensures that the route is protected from abuse without affecting other parts of the application.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
